### PR TITLE
fix(denops): pcall を使用して win_close のエラーを抑制する

### DIFF
--- a/denops/denops-mode-change-notify/main.ts
+++ b/denops/denops-mode-change-notify/main.ts
@@ -49,13 +49,9 @@ export const main: Entrypoint = (denops) => {
       });
 
       setTimeout(async () => {
-        try {
-          const isValid = await nvim.nvim_win_is_valid(denops, win);
-          if (isValid) {
-            await nvim.nvim_win_close(denops, win, true);
-          }
-        } catch (error) {
-          console.warn(`Failed to close window: ${error}`);
+        const isValid = await nvim.nvim_win_is_valid(denops, win);
+        if (isValid) {
+          await denops.call("pcall", "nvim_win_close", win, true);
         }
       }, timeout);
     },


### PR DESCRIPTION
win_close を実行する際に、ウィンドウがすでに閉じられているなどの理由でエラーが発生することがありました。

あなたの要望に基づき、`try...catch` の代わりに Vim の `pcall` を使用して `nvim_win_close` を呼び出すように変更しました。これにより、エラーが捕捉され、プラグインの動作が不安定になるのを防ぎます。

---

fix(denops): Use pcall to suppress win_close errors

When executing win_close, an error sometimes occurred because the window was already closed.

Based on your request, I've changed the code to use Vim's `pcall` to call `nvim_win_close` instead of a `try...catch` block. This ensures that any errors are caught, preventing the plugin from becoming unstable.