### PR TITLE
feat: Set ambiwidth=single for notification windows

### DIFF
--- a/denops/denops-mode-change-notify/main.ts
+++ b/denops/denops-mode-change-notify/main.ts
@@ -219,6 +219,7 @@ export const main: Entrypoint = (denops) => {
       await fn.setwinvar(denops, winid, "&statusline", "");
       await fn.setwinvar(denops, winid, "&cursorline", 0);
       await fn.setwinvar(denops, winid, "&list", 0);
+      await fn.setwinvar(denops, winid, "&ambiwidth", "single");
       lastVimPopupWinid = winid;
       setTimeout(async () => {
         try {
@@ -256,6 +257,8 @@ export const main: Entrypoint = (denops) => {
         focusable: false,
         noautocmd: true,
       });
+      await nvim.nvim_win_set_option(denops, win, "ambiwidth", "single");
+      lastNvimWinid = win;
       setTimeout(async () => {
         try {
           const isValid = await nvim.nvim_win_is_valid(denops, win);


### PR DESCRIPTION
Forcibly sets `setlocal ambiwidth=single` for the popup/floating windows created by the plugin. This resolves display issues in environments where ambiwidth characters are rendered as single-width, preventing character overlap and layout corruption in the notification window.

The change is applied to both the Vim (popup_create) and Neovim (nvim_open_win) implementations.

Additionally, a minor bug was fixed in the Neovim implementation where the window ID of the last notification was not being stored, which could lead to overlapping windows.